### PR TITLE
DO NOT MERGE: add ordering example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bootstrap.json
 build/
 ext/
 node_modules
+**/sass/example
 **/docs/api
 **/example/example.css
 *~

--- a/packages/mf-grid-filter-form/.sencha/package/codegen.json
+++ b/packages/mf-grid-filter-form/.sencha/package/codegen.json
@@ -30,88 +30,88 @@
       "source": "package.json.tpl.merge",
       "version": "9c7e7135be031f8d06045d338200cbf4a4222f88",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     "sass/config.rb": {
       "source": "config.rb.tpl.merge",
       "version": "33f446bd02c3fd24eb27891582eff6a2e789796b",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     "sass/etc/all.scss": {
       "source": "all.scss.merge",
       "version": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     "sass/example/custom.js": {
       "source": "custom.js.merge",
       "version": "199e99bbd15c3c0415569425cb21e77c95e9042a",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     "sass/example/theme.html": {
       "source": "theme.html.tpl.merge",
       "version": "32f685a8af28baafcc7999862d0bd1f25df0e48b",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     ".sencha/package/build.properties": {
       "source": "build.properties.merge",
       "version": "8b81315dbe73ce9c08478f4c1d2df84f456efcf5",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     ".sencha/package/sencha.cfg": {
       "source": "sencha.cfg.tpl.merge",
       "version": "6d1982cce48163a98dc46012d1d0cdfa209fbda6",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     },
     ".sencha/package/testing.properties": {
       "source": "testing.properties.merge",
       "version": "e65f969c42eb4f355c850fc58fea852582f20db8",
       "parameters": {
-        "extRelPath": "../${ext.dir}",
+        "extRelPath": "../../ext",
         "pkgName": "mf-grid-filter-form",
         "pkgType": "code",
         "senchadir": ".sencha",
-        "touchRelPath": "../${touch.dir}"
+        "touchRelPath": "${touch.dir}"
       }
     }
   }

--- a/packages/mf-grid-filter-form/.sencha/package/sencha.cfg
+++ b/packages/mf-grid-filter-form/.sencha/package/sencha.cfg
@@ -57,7 +57,7 @@ package.subpkgs.dir=${package.dir}/packages
 # Custom Properties - Place customizations below this line to avoid merge
 # conflicts with newer versions
 
-package.cmd.version=5.1.2.52
+package.cmd.version=5.1.3.61
 
 # You’ll need to manually add a package.framework designation to your PackageName/.sencha/package/sencha.cfg file.
 #

--- a/packages/mf-grid-filter-form/examples/simple-grid/app/view/main/Main.js
+++ b/packages/mf-grid-filter-form/examples/simple-grid/app/view/main/Main.js
@@ -38,7 +38,7 @@ Ext.define('SimpleGrid.view.main.Main', {
         region: 'center',
         xtype: 'tabpanel',
         items:[{
-            title: 'Grid with filter from',
+            title: 'Grid with filter form',
             items: [{
                 xtype: 'grid',
                 layout: 'fit',
@@ -81,6 +81,34 @@ Ext.define('SimpleGrid.view.main.Main', {
                 xtype: 'remotenumbergrid',
                 layout: 'fit',
                 height: 300
+            }]
+        }, {
+            title: 'Grid with ordered paging bar',
+            items: [{
+                xtype: 'grid',
+                layout: 'fit',
+                features: [Ext.create('Mayflower.grid.feature.FilterForm')],
+                store: {
+                    type: 'localnumber',
+                    pageSize: 5
+                },
+                columns: [{
+                    text: 'Id',
+                    dataIndex: 'id',
+                    flex: 1,
+                    filterOption: {}
+                }, {
+                    text: 'Description',
+                    dataIndex: 'description',
+                    flex: 1,
+                    filterOption: {formPosition: 1}
+                }, {
+                    text: 'Name',
+                    dataIndex: 'name',
+                    flex: 1,
+                    filterOption: {formPosition: 0}
+                }],
+                bbar: [{xtype: 'pagingtoolbar', store: {type: 'localnumber'}}]
             }]
         }]
     }]


### PR DESCRIPTION
This adds an example for the field ordering in the paging bar and the result of a ```sencha package upgrade```, however there's a minor problem that should have been caught by the tests, so I have no idea why the application exposes this behaviour.